### PR TITLE
fix(categories): отсекать HTML-фоллбэк от GET /categories

### DIFF
--- a/src/js/services/categoryService.ts
+++ b/src/js/services/categoryService.ts
@@ -1,7 +1,3 @@
-/**
- * Сервис для работы с категориями и характеристиками
- */
-
 import { apiClient } from '@/api/apiClient';
 import type { Category, CategoryCharacteristic } from '@/types';
 
@@ -15,18 +11,10 @@ const API_ENDPOINTS = {
 const CATEGORIES_CACHE_KEY = 'clover_categories';
 const CHARS_CACHE_PREFIX = 'clover_cat_chars_';
 
-// На текущий момент бэкенд возвращает 404 для /categories и
-// /categories/:id/characteristics. Чтобы не засорять network tab битыми
-// запросами, отключаем сетевой вызов после первой 404 в рамках сессии.
 let _categoriesEndpointDisabled = false;
 let _charsEndpointDisabled = false;
 
 export const categoryService = {
-    /**
-     * Получение всех категорий (с кэшированием в localStorage).
-     * Если backend ещё не реализовал /categories — возвращаем фолбэк
-     * без сетевых попыток до перезагрузки страницы.
-     */
     async getAllCategories(): Promise<Category[]> {
         if (_categoriesEndpointDisabled) {
             return this.getCachedCategories() || this.getFallbackCategories();
@@ -35,20 +23,23 @@ export const categoryService = {
         try {
             const result = await apiClient.get<Category[]>(API_ENDPOINTS.CATEGORIES.GET_ALL);
 
-            if (result.success && result.data) {
+            if (result.success && Array.isArray(result.data)) {
                 try {
                     localStorage.setItem(CATEGORIES_CACHE_KEY, JSON.stringify(result.data));
                 } catch {
-                    // localStorage может быть переполнен или заблокирован
+                    /* ignore */
                 }
                 return result.data;
             }
 
-            if (result.status === 404) {
-                _categoriesEndpointDisabled = true;
+            _categoriesEndpointDisabled = true;
+            try {
+                localStorage.removeItem(CATEGORIES_CACHE_KEY);
+            } catch {
+                /* ignore */
             }
         } catch {
-            // Сетевая ошибка — пойдём в фолбек
+            /* ignore */
         }
 
         const cached = this.getCachedCategories();
@@ -57,16 +48,16 @@ export const categoryService = {
         return this.getFallbackCategories();
     },
 
-    /**
-     * Получение характеристик категории (с кэшированием).
-     */
     async getCategoryCharacteristics(categoryId: number): Promise<CategoryCharacteristic[]> {
         const readCache = (): CategoryCharacteristic[] => {
             try {
                 const cached = localStorage.getItem(CHARS_CACHE_PREFIX + categoryId);
-                if (cached) return JSON.parse(cached);
+                if (cached) {
+                    const parsed = JSON.parse(cached);
+                    if (Array.isArray(parsed)) return parsed;
+                }
             } catch {
-                // Невалидный JSON или недоступный localStorage
+                /* ignore */
             }
             return [];
         };
@@ -78,21 +69,21 @@ export const categoryService = {
                 API_ENDPOINTS.CATEGORIES.GET_CHARACTERISTICS(categoryId),
             );
 
-            if (result.success && result.data) {
-                const sorted = result.data.sort((a, b) => a.sort_order - b.sort_order);
+            if (result.success && Array.isArray(result.data)) {
+                const sorted = [...result.data].sort((a, b) => a.sort_order - b.sort_order);
                 try {
                     localStorage.setItem(CHARS_CACHE_PREFIX + categoryId, JSON.stringify(sorted));
                 } catch {
-                    // localStorage может быть переполнен или заблокирован
+                    /* ignore */
                 }
                 return sorted;
             }
 
-            if (result.status === 404) {
+            if (result.status === 404 || (result.success && !Array.isArray(result.data))) {
                 _charsEndpointDisabled = true;
             }
         } catch {
-            // Сетевая ошибка — пойдём в фолбек из localStorage
+            /* ignore */
         }
 
         return readCache();
@@ -101,16 +92,19 @@ export const categoryService = {
     getCachedCategories(): Category[] | null {
         try {
             const cached = localStorage.getItem(CATEGORIES_CACHE_KEY);
-            if (cached) return JSON.parse(cached);
+            if (!cached) return null;
+            const parsed = JSON.parse(cached);
+            if (!Array.isArray(parsed)) {
+                localStorage.removeItem(CATEGORIES_CACHE_KEY);
+                return null;
+            }
+            return parsed;
         } catch {
-            // Невалидный JSON или недоступный localStorage
+            /* ignore */
         }
         return null;
     },
 
-    /**
-     * Фолбэк-категории (на случай, если API еще не готов)
-     */
     getFallbackCategories(): Category[] {
         return [
             { id: 1, name: 'Электроника' },


### PR DESCRIPTION
Проверять Array.isArray перед использованием ответа, чистить мусорный localStorage. Без этого при SPA-fallback фронт получал {message: '<html>...'} как массив и ломал дропдаун категорий, из-за чего характеристики не подтягивались.