### PR TITLE
fix(wallet): показывать баннер ожидания после редиректа с ЮКассы

### DIFF
--- a/src/modules/wallet/components/wallet-tab/wallet-tab.hbs
+++ b/src/modules/wallet/components/wallet-tab/wallet-tab.hbs
@@ -7,6 +7,19 @@
     <button class="btn btn-primary wallet-topup-btn" data-action="open-topup">Пополнить</button>
 </div>
 
+{{#if pendingTopup}}
+    <div class="wallet-pending-banner" role="status" aria-live="polite">
+        <span class="wallet-pending-spinner" aria-hidden="true"></span>
+        <div class="wallet-pending-text">
+            <div class="wallet-pending-title">Ожидаем подтверждение от банка</div>
+            <div class="wallet-pending-sub">
+                Платёж на <strong>{{pendingTopup.formattedAmount}}</strong> обрабатывается.
+                Деньги поступят на баланс в течение нескольких минут, можно не закрывать страницу.
+            </div>
+        </div>
+    </div>
+{{/if}}
+
 <div class="wallet-transactions">
     <h3 class="wallet-transactions-title">История операций</h3>
     {{#if transactions.length}}

--- a/src/modules/wallet/components/wallet-tab/wallet-tab.scss
+++ b/src/modules/wallet/components/wallet-tab/wallet-tab.scss
@@ -36,6 +36,52 @@
     }
 }
 
+.wallet-pending-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 20px;
+    color: #5d4037;
+}
+
+.wallet-pending-spinner {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid #ffb300;
+    border-top-color: transparent;
+    animation: wallet-pending-spin 0.9s linear infinite;
+    margin-top: 2px;
+}
+
+@keyframes wallet-pending-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.wallet-pending-text {
+    flex: 1;
+    line-height: 1.4;
+}
+
+.wallet-pending-title {
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 4px;
+    color: #4e342e;
+}
+
+.wallet-pending-sub {
+    font-size: 13px;
+    color: #6d4c41;
+}
+
 .wallet-transactions-title {
     font-size: 16px;
     font-weight: 600;

--- a/src/modules/wallet/components/wallet-tab/wallet-tab.ts
+++ b/src/modules/wallet/components/wallet-tab/wallet-tab.ts
@@ -116,6 +116,12 @@ export const WalletTab = {
                         : `${Math.abs(tx.amount).toLocaleString('ru-RU')} ₽`,
             })),
             nextCursor: state.nextCursor,
+            pendingTopup: state.pendingTopup
+                ? {
+                      ...state.pendingTopup,
+                      formattedAmount: `${state.pendingTopup.amount.toLocaleString('ru-RU')} ₽`,
+                  }
+                : null,
         };
     },
 

--- a/src/modules/wallet/payment-polling.ts
+++ b/src/modules/wallet/payment-polling.ts
@@ -59,54 +59,90 @@ function getPendingPaymentId(): number | null {
     return Number.isFinite(id) && id > 0 ? id : null;
 }
 
-// handleTopupReturn вызывается при заходе на /wallet с ?topup=done. Дожидается
-// результата на бэке, показывает тост, обновляет баланс.
+function getPendingAmount(): number {
+    const raw = sessionStorage.getItem(TOPUP_PENDING_AMOUNT_KEY);
+    const n = raw ? Number.parseInt(raw, 10) : 0;
+    return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+// markPending выставляет в стор баннер «Ожидаем подтверждение от банка»
+// и эмитит wallet:updated, чтобы вкладка кошелька перерендерилась с баннером.
+function markPending(paymentId: number, amount: number): void {
+    walletStore.setState({ pendingTopup: { paymentId, amount } });
+    eventBus.emit('wallet:updated');
+}
+
+// finalizePending очищает sessionStorage, снимает баннер, обновляет баланс
+// и подгружает свежий список транзакций (чтобы появилась строка пополнения).
+async function finalizePending(): Promise<void> {
+    clearPendingPayment();
+    walletStore.setState({ pendingTopup: null });
+
+    await walletStore.fetchBalance();
+    const txRes = await walletService.getTransactions(20);
+    if (txRes.success && txRes.data) {
+        walletStore.setState({
+            transactions: txRes.data.items,
+            nextCursor: txRes.data.next_cursor ?? null,
+        });
+    }
+
+    eventBus.emit('wallet:updated');
+}
+
+// handleTopupReturn вызывается при заходе на /profile?tab=wallet&topup=done.
+// Показывает баннер ожидания, поллит статус, при успехе перерендеривает
+// кошелёк (свежий баланс + новая строка в истории операций).
 async function handleTopupReturn(): Promise<void> {
     const paymentId = getPendingPaymentId();
     if (!paymentId) {
         return;
     }
 
-    uiActions.showInfo('Ожидаем подтверждение от банка…');
+    markPending(paymentId, getPendingAmount());
+
     const result = await pollPaymentStatus(paymentId);
 
     if (result.status === 'succeeded') {
-        await walletStore.fetchBalance();
+        await finalizePending();
         uiActions.showSuccess(`Зачислено ${result.amount.toLocaleString('ru-RU')} ₽`);
-        eventBus.emit('wallet:updated');
-        clearPendingPayment();
-    } else if (result.status === 'failed' || result.status === 'cancelled') {
-        uiActions.showError('Оплата не прошла');
-        clearPendingPayment();
-    } else {
-        // timeout: webhook ещё не дошёл / reconciler подберёт позже
-        uiActions.showInfo(
-            'Платёж обрабатывается. Баланс обновится автоматически в течение нескольких минут.',
-        );
-        // sessionStorage НЕ чистим — при следующем заходе на /wallet поллинг
-        // пройдёт ещё раз и подберёт финальный статус.
+        return;
     }
+
+    if (result.status === 'failed' || result.status === 'cancelled') {
+        clearPendingPayment();
+        walletStore.setState({ pendingTopup: null });
+        eventBus.emit('wallet:updated');
+        uiActions.showError('Оплата не прошла');
+        return;
+    }
+
+    // timeout: webhook ещё не дошёл / reconciler подберёт позже. Баннер
+    // оставляем на странице — юзер видит, что платёж в обработке. При
+    // следующем заходе на /wallet silentPollPendingPayment подберёт статус.
 }
 
 // silentPollPendingPayment вызывается при обычном заходе на /wallet (без query-param):
-// если у юзера лежит незавершённый payment_id в sessionStorage — тихо чекнем его
-// статус один раз и обновим баланс, если зачислился.
+// если у юзера лежит незавершённый payment_id в sessionStorage — показываем баннер
+// ожидания, тихо чекаем статус один раз и перерендериваем при необходимости.
 async function silentPollPendingPayment(): Promise<void> {
     const paymentId = getPendingPaymentId();
     if (!paymentId) return;
+
+    markPending(paymentId, getPendingAmount());
 
     const res = await walletService.getPaymentStatus(paymentId);
     if (!res.success || !res.data) {
         return;
     }
     if (res.data.status === 'succeeded') {
-        await walletStore.fetchBalance();
-        eventBus.emit('wallet:updated');
-        clearPendingPayment();
+        await finalizePending();
     } else if (res.data.status === 'failed' || res.data.status === 'cancelled') {
         clearPendingPayment();
+        walletStore.setState({ pendingTopup: null });
+        eventBus.emit('wallet:updated');
     }
-    // pending — оставляем, попробуем при следующем заходе
+    // pending — оставляем баннер, попробуем при следующем заходе
 }
 
 export { handleTopupReturn, silentPollPendingPayment, clearPendingPayment, getPendingPaymentId };

--- a/src/modules/wallet/store.ts
+++ b/src/modules/wallet/store.ts
@@ -14,6 +14,7 @@ class WalletStore {
         nextCursor: null,
         error: null,
         isLoading: false,
+        pendingTopup: null,
     };
 
     private eventBus: EventBus;

--- a/src/modules/wallet/types.ts
+++ b/src/modules/wallet/types.ts
@@ -39,6 +39,11 @@ export interface PaymentStatusResponse {
     confirmation_url?: string;
 }
 
+export interface PendingTopup {
+    paymentId: number;
+    amount: number;
+}
+
 export interface WalletState {
     balance: number;
     currency: string;
@@ -46,4 +51,5 @@ export interface WalletState {
     nextCursor: number | null;
     error: string | null;
     isLoading: boolean;
+    pendingTopup: PendingTopup | null;
 }


### PR DESCRIPTION
После возврата с return_url пользователь видит баннер «Ожидаем подтверждение от банка» прямо в кошельке вместо незаметного тоста. По завершении поллинга баннер снимается, баланс обновляется и подгружается свежий список транзакций — строка пополнения появляется в истории операций без ручного рефреша.

- WalletState получил поле pendingTopup; шаблон wallet-tab рисует баннер с суммой, если оно выставлено
- handleTopupReturn выставляет pendingTopup перед поллингом и снимает его на success/fail/cancel, на timeout оставляет (юзер видит, что платёж в обработке)
- silentPollPendingPayment делает то же при обычном заходе на /wallet с висящим pending в sessionStorage
- finalizePending перезагружает balance + transactions и эмитит wallet:updated, что триггерит rerender вкладки и сайдбара