### PR TITLE
fix(price-history): стабильный рендер графика, агрегация по дню, статы

### DIFF
--- a/src/modules/announcements/ad-detail/css/ad-detail.scss
+++ b/src/modules/announcements/ad-detail/css/ad-detail.scss
@@ -868,30 +868,19 @@
 
 
 .price-history-row {
-    margin: 12px 0 8px 0;
+    margin: 0 0 10px 0;
 }
 
-.price-history-trigger {
+.ad-detail-page .price-history-trigger.action-btn {
     width: 100%;
-    background: none;
+    background: #f5f5f5;
+    color: #333;
     border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 8px 16px;
-    font-size: 14px;
-    color: #666;
-    cursor: pointer;
-    transition: all 0.2s;
-    
-    &:hover {
-        border-color: #2bde8c;
-        background: #f5fcf8;
-        color: #2bde8c;
-    }
-}
 
-@media (max-width: 768px) {
-    .price-history-trigger {
-        font-size: 12px;
-        padding: 5px 12px;
+    &:hover {
+        background: #eaf9f1;
+        border-color: #2bde8c;
+        color: #2bde8c;
+        transform: translateY(-1px);
     }
 }

--- a/src/modules/announcements/ad-detail/templates/ad-detail.hbs
+++ b/src/modules/announcements/ad-detail/templates/ad-detail.hbs
@@ -149,8 +149,8 @@
                     <!-- КНОПКА ИСТОРИИ ЦЕН -->
                     {{#if hasPriceHistory}}
                     <div class="price-history-row">
-                        <button class="price-history-trigger" data-action="show-price-history" title="История изменения цены">
-                             История цены
+                        <button class="action-btn price-history-trigger" data-action="show-price-history" title="История изменения цены">
+                            История цены
                         </button>
                     </div>
                     {{/if}}

--- a/src/modules/announcements/price-history/components/price-chart/price-chart.ts
+++ b/src/modules/announcements/price-history/components/price-chart/price-chart.ts
@@ -1,4 +1,11 @@
-import { createChart, ColorType, CrosshairMode, IChartApi, ISeriesApi } from 'lightweight-charts';
+import {
+    createChart,
+    ColorType,
+    CrosshairMode,
+    LineSeries,
+    IChartApi,
+    ISeriesApi,
+} from 'lightweight-charts';
 import type { ChartPoint } from '../../types';
 import { formatDateForDisplay } from '../../utils';
 
@@ -7,6 +14,9 @@ export class PriceHistoryChart {
     private series: ISeriesApi<'Line'> | null = null;
     private container: HTMLElement | null = null;
     private tooltip: HTMLElement | null = null;
+    private resizeObserver: ResizeObserver | null = null;
+    private resizeHandler: (() => void) | null = null;
+    private pendingData: ChartPoint[] | null = null;
 
     init(containerId: string): void {
         this.container = document.getElementById(containerId) as HTMLElement | null;
@@ -36,11 +46,19 @@ export class PriceHistoryChart {
         this.container?.appendChild(this.tooltip);
     }
 
+    private getContainerWidth(): number {
+        if (!this.container) return 0;
+        const rect = this.container.getBoundingClientRect();
+        return Math.max(rect.width || this.container.clientWidth || 0, 0);
+    }
+
     private createChart(): void {
         if (!this.container) return;
 
+        const initialWidth = this.getContainerWidth() || 600;
+
         this.chart = createChart(this.container, {
-            width: this.container.clientWidth,
+            width: initialWidth,
             height: 280,
             layout: {
                 background: { type: ColorType.Solid, color: '#ffffff' },
@@ -55,7 +73,7 @@ export class PriceHistoryChart {
                 vertLine: {
                     width: 1,
                     color: '#2bde8c',
-                    style: 2, // LineStyle.Dashed
+                    style: 2,
                     labelBackgroundColor: '#2bde8c',
                 },
                 horzLine: {
@@ -68,8 +86,7 @@ export class PriceHistoryChart {
             rightPriceScale: {
                 borderColor: '#e0e0e0',
                 textColor: '#666',
-                // visible: true,
-                mode: 0, // 0 = normal, 1 = logarithmic, 2 = percentage
+                mode: 0,
                 scaleMargins: {
                     top: 0.15,
                     bottom: 0.15,
@@ -80,15 +97,12 @@ export class PriceHistoryChart {
                 borderColor: '#e0e0e0',
                 tickMarkFormatter: (time: number | string) => {
                     let date: Date;
-
                     if (typeof time === 'string') {
                         date = new Date(time);
                     } else {
                         date = new Date(time * 1000);
                     }
-
                     if (isNaN(date.getTime())) return '';
-
                     const day = date.getDate().toString().padStart(2, '0');
                     const month = (date.getMonth() + 1).toString().padStart(2, '0');
                     return `${day}.${month}`;
@@ -100,7 +114,6 @@ export class PriceHistoryChart {
             },
         });
 
-        // Используем addSeries вместо addLineSeries
         this.series = this.chart.addSeries(LineSeries, {
             color: '#2bde8c',
             lineWidth: 2,
@@ -112,31 +125,34 @@ export class PriceHistoryChart {
             crosshairMarkerBackgroundColor: '#2bde8c',
             priceFormat: {
                 type: 'price',
-                precision: 0, // ← 0 знаков после запятой
-                minMove: 1, // ← минимальный шаг 1
+                precision: 0,
+                minMove: 1,
             },
         });
 
-        // Подписка на движение курсора
         this.chart.subscribeCrosshairMove((param) => {
-            if (!this.tooltip || !param.point || !param.time) {
+            if (!this.tooltip || !param.point || !param.time || !this.series) {
                 this.hideTooltip();
                 return;
             }
 
-            // Получаем цену через seriesData
-            const price = param.seriesData.get(this.series!);
-            if (!price || typeof price === 'object') {
+            const price = param.seriesData.get(this.series);
+            if (!price || typeof price !== 'object' || !('value' in price)) {
                 this.hideTooltip();
                 return;
             }
 
-            const date = new Date((param.time as number) * 1000);
+            let date: Date;
+            if (typeof param.time === 'string') {
+                date = new Date(param.time);
+            } else {
+                date = new Date((param.time as number) * 1000);
+            }
             const dateStr = formatDateForDisplay(date.toISOString());
 
+            const priceValue = (price as { value: number }).value;
             this.tooltip.style.display = 'block';
-            this.tooltip.innerHTML = `${dateStr}<br><strong>${price} ₽</strong>`;
-
+            this.tooltip.innerHTML = `${dateStr}<br><strong>${priceValue.toLocaleString('ru-RU')} ₽</strong>`;
             this.tooltip.style.left = `${param.point.x}px`;
             this.tooltip.style.top = `${param.point.y - 40}px`;
         });
@@ -145,21 +161,33 @@ export class PriceHistoryChart {
             this.hideTooltip();
         });
 
-        window.addEventListener('resize', () => this.resize());
+        // ResizeObserver вместо window resize — реагирует на изменения родителя
+        if (typeof ResizeObserver !== 'undefined') {
+            this.resizeObserver = new ResizeObserver(() => this.resize());
+            this.resizeObserver.observe(this.container);
+        }
+
+        this.resizeHandler = () => this.resize();
+        window.addEventListener('resize', this.resizeHandler);
     }
 
     setData(points: ChartPoint[]): void {
-        if (!this.series) return;
+        if (!this.series || !this.chart) return;
 
         const chartData = points.map((point) => ({
-            time: point.time,
+            time: point.time as never,
             value: point.value,
         }));
 
+        this.pendingData = points;
         this.series.setData(chartData);
 
-        if (this.chart && chartData.length > 0) {
-            this.chart.timeScale().fitContent();
+        if (chartData.length > 0) {
+            // Если контейнер только что показан и ширина была 0 — ждём кадр и подгоняем
+            requestAnimationFrame(() => {
+                this.resize();
+                this.chart?.timeScale().fitContent();
+            });
         }
     }
 
@@ -170,12 +198,11 @@ export class PriceHistoryChart {
     }
 
     resize(): void {
-        if (this.chart && this.container) {
-            this.chart.applyOptions({ width: this.container.clientWidth });
-            setTimeout(() => {
-                this.chart?.timeScale().fitContent();
-            }, 100);
-        }
+        if (!this.chart || !this.container) return;
+        const width = this.getContainerWidth();
+        if (width <= 0) return;
+        this.chart.applyOptions({ width });
+        this.chart.timeScale().fitContent();
     }
 
     showLoader(show: boolean): void {
@@ -193,6 +220,14 @@ export class PriceHistoryChart {
     }
 
     destroy(): void {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
+        if (this.resizeHandler) {
+            window.removeEventListener('resize', this.resizeHandler);
+            this.resizeHandler = null;
+        }
         if (this.chart) {
             this.chart.remove();
             this.chart = null;
@@ -202,8 +237,6 @@ export class PriceHistoryChart {
             this.tooltip.remove();
             this.tooltip = null;
         }
+        this.pendingData = null;
     }
 }
-
-// Импортируем LineSeries после createChart
-import { LineSeries } from 'lightweight-charts';

--- a/src/modules/announcements/price-history/modal/price-history-modal.hbs
+++ b/src/modules/announcements/price-history/modal/price-history-modal.hbs
@@ -26,6 +26,10 @@
                     <span class="stat-label">Изменений</span>
                     <span class="stat-value changes-count"></span>
                 </div>
+                <div class="price-history-stat extra-stat">
+                    <span class="stat-label">Изменений сегодня</span>
+                    <span class="stat-value changes-today"></span>
+                </div>
             </div>
         </div>
     </div>

--- a/src/modules/announcements/price-history/modal/price-history-modal.scss
+++ b/src/modules/announcements/price-history/modal/price-history-modal.scss
@@ -83,32 +83,38 @@
 }
 
 .price-history-stats-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 24px;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
+    align-items: start;
 }
 
 .price-history-stat {
-    flex: 1;
-    min-width: 100px;
+    min-width: 0;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
 }
 
 .stat-label {
     display: block;
-    font-size: 12px;
+    font-size: 11px;
+    line-height: 1.2;
     color: #999;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 4px;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    margin-bottom: 0;
 }
 
 .stat-value {
     display: block;
-    font-size: 20px;
+    font-size: 18px;
     font-weight: 700;
     color: #333;
+    white-space: nowrap;
 }
 
 .stat-value.current-price {
@@ -145,49 +151,45 @@
         width: 95%;
         max-height: 90vh;
     }
-    
+
     .price-history-title {
         font-size: 18px;
         padding: 20px 20px 12px;
     }
-    
+
     .price-chart-wrapper {
         padding: 12px 16px;
         min-height: 260px;
     }
-    
+
     .price-history-stats {
         padding: 12px 16px 20px;
     }
-    
+
     .price-history-stats-grid {
-        gap: 12px;
+        gap: 8px;
     }
-    
+
+    .stat-label {
+        font-size: 10px;
+    }
+
     .stat-value {
-        font-size: 16px;
+        font-size: 14px;
     }
 }
 
 @media (max-width: 480px) {
     .price-history-stats-grid {
-        flex-direction: column;
-        gap: 10px;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
     }
-    
+
     .price-history-stat {
-        text-align: left;
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        flex-wrap: wrap;
+        text-align: center;
     }
-    
-    .stat-label {
-        margin-bottom: 0;
-    }
-    
+
     .stat-value {
-        font-size: 18px;
+        font-size: 16px;
     }
 }

--- a/src/modules/announcements/price-history/modal/price-history-modal.ts
+++ b/src/modules/announcements/price-history/modal/price-history-modal.ts
@@ -81,10 +81,11 @@ export class PriceHistoryModal {
 
         if (chartPoints.length === 0) {
             this.showError('Не удалось загрузить данные для графика');
+            this.showLoader(false);
             return;
         }
 
-        const stats = calculateStats(chartPoints, data.currentPrice, history.length);
+        const stats = calculateStats(chartPoints, data.currentPrice, history);
         const hasMultiplePrices = stats.minPrice !== stats.maxPrice;
 
         this.updateStats(stats, data, hasMultiplePrices);
@@ -112,7 +113,10 @@ export class PriceHistoryModal {
     }
 
     private async renderChart(points: any[]): Promise<void> {
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // Ждём 2 кадра — гарантируем, что модалка вычислила свою ширину
+        await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        );
 
         const container = document.getElementById('priceHistoryChartContainer');
         if (!container) return;
@@ -146,6 +150,7 @@ export class PriceHistoryModal {
         const maxPriceEl = this.modalElement.querySelector('.max-price');
         const maxDateEl = this.modalElement.querySelector('.max-date');
         const changesEl = this.modalElement.querySelector('.changes-count');
+        const changesTodayEl = this.modalElement.querySelector('.changes-today');
         const extraStats = this.modalElement.querySelectorAll('.extra-stat');
 
         if (hasMultiplePrices) {
@@ -154,6 +159,7 @@ export class PriceHistoryModal {
             if (maxPriceEl) maxPriceEl.textContent = `${stats.maxPrice.toLocaleString('ru-RU')} ₽`;
             if (maxDateEl) maxDateEl.textContent = stats.maxPriceDate;
             if (changesEl) changesEl.textContent = String(stats.changesCount);
+            if (changesTodayEl) changesTodayEl.textContent = String(stats.changesToday);
             extraStats.forEach((el) => el.classList.remove('hidden'));
         } else {
             extraStats.forEach((el) => el.classList.add('hidden'));

--- a/src/modules/announcements/price-history/types.ts
+++ b/src/modules/announcements/price-history/types.ts
@@ -18,6 +18,7 @@ export interface ChartStats {
     maxPrice: number;
     maxPriceDate: string;
     changesCount: number;
+    changesToday: number;
 }
 
 export interface PriceHistoryData {

--- a/src/modules/announcements/price-history/utils.ts
+++ b/src/modules/announcements/price-history/utils.ts
@@ -23,6 +23,42 @@ export function formatDateForChart(dateString: string): string {
     return `${year}-${month}-${day}`;
 }
 
+/**
+ * Группирует историю по дню. Для каждого дня берём ПОСЛЕДНЕЕ изменение (по changed_at).
+ * Возвращает массив { day, lastPrice, count } отсортированный по дню (возр.).
+ */
+export function aggregateByDay(
+    history: PriceHistoryPoint[],
+): { day: string; lastPrice: number; count: number; lastChangedAt: string }[] {
+    const map = new Map<
+        string,
+        { day: string; lastPrice: number; count: number; lastChangedAt: string }
+    >();
+
+    for (const point of history) {
+        const day = formatDateForChart(point.changed_at);
+        if (!day) continue;
+        const existing = map.get(day);
+        if (!existing) {
+            map.set(day, {
+                day,
+                lastPrice: point.price,
+                count: 1,
+                lastChangedAt: point.changed_at,
+            });
+        } else {
+            existing.count += 1;
+            // берём последний по времени
+            if (new Date(point.changed_at).getTime() > new Date(existing.lastChangedAt).getTime()) {
+                existing.lastPrice = point.price;
+                existing.lastChangedAt = point.changed_at;
+            }
+        }
+    }
+
+    return Array.from(map.values()).sort((a, b) => (a.day < b.day ? -1 : 1));
+}
+
 export function convertToChartPoints(
     history: PriceHistoryPoint[],
     createdAt: string,
@@ -31,37 +67,28 @@ export function convertToChartPoints(
     const points: ChartPoint[] = [];
 
     if (!history.length) {
-        points.push({
-            time: formatDateForChart(createdAt),
-            value: currentPrice,
-        });
+        const createdDay = formatDateForChart(createdAt);
+        if (createdDay) {
+            points.push({ time: createdDay, value: currentPrice });
+        }
 
         const today = formatDateForChart(new Date().toISOString());
-        if (today !== formatDateForChart(createdAt)) {
-            points.push({
-                time: today,
-                value: currentPrice,
-            });
+        if (today && today !== createdDay) {
+            points.push({ time: today, value: currentPrice });
         }
 
         return points;
     }
 
-    for (const point of history) {
-        points.push({
-            time: formatDateForChart(point.changed_at),
-            value: point.price,
-        });
+    const daily = aggregateByDay(history);
+    for (const d of daily) {
+        points.push({ time: d.day, value: d.lastPrice });
     }
 
-    const lastPoint = points[points.length - 1];
     const today = formatDateForChart(new Date().toISOString());
-
-    if (lastPoint.time !== today) {
-        points.push({
-            time: today,
-            value: currentPrice,
-        });
+    const lastPoint = points[points.length - 1];
+    if (lastPoint && lastPoint.time !== today) {
+        points.push({ time: today, value: currentPrice });
     }
 
     return points;
@@ -70,7 +97,7 @@ export function convertToChartPoints(
 export function calculateStats(
     points: ChartPoint[],
     currentPrice: number,
-    changesCount: number,
+    history: PriceHistoryPoint[],
 ): ChartStats {
     let minPrice = Infinity;
     let maxPrice = -Infinity;
@@ -88,6 +115,13 @@ export function calculateStats(
         }
     }
 
+    const changesCount = history.length;
+    const today = formatDateForChart(new Date().toISOString());
+    const changesToday = history.reduce(
+        (acc, p) => (formatDateForChart(p.changed_at) === today ? acc + 1 : acc),
+        0,
+    );
+
     return {
         currentPrice,
         minPrice: minPrice === Infinity ? currentPrice : minPrice,
@@ -95,5 +129,6 @@ export function calculateStats(
         maxPrice: maxPrice === -Infinity ? currentPrice : maxPrice,
         maxPriceDate: maxPriceDate || formatDateForDisplay(points[0]?.time || ''),
         changesCount,
+        changesToday,
     };
 }


### PR DESCRIPTION
- price-chart: ResizeObserver + getBoundingClientRect для корректной ширины, requestAnimationFrame вместо setTimeout, LineSeries перенесён в верх импортов, fix тултипа (читаем price.value), снятие resize listener в destroy
- utils: aggregateByDay — одна точка за день (последнее изменение)
- stats: добавлено поле "Изменений сегодня"
- modal: 2 кадра ожидания перед init графика, сетка 5 колонок, nowrap лейблов
- ad-detail: кнопка "История цены" приведена к стилю .action-btn